### PR TITLE
Remove placeholder ref from getChunk

### DIFF
--- a/core/components/cookiejar/elements/snippets/snippet.getcookie.php
+++ b/core/components/cookiejar/elements/snippets/snippet.getcookie.php
@@ -41,7 +41,7 @@ if(isset($name) && isset($_COOKIE[$name])) {
     }
     if (!empty($tpl)) {
       $ph = $modx->setPlaceholder($toPlaceholder,$cookie);
-      $result = $modx->getChunk($tpl,$ph);
+      $result = $modx->getChunk($tpl);
     }
   }
 }else{


### PR DESCRIPTION
Placeholder are set globally, no need to be referenced in getChunk.
Fixes soft error in log.